### PR TITLE
Feature/register arguments

### DIFF
--- a/include/kroshu_ros2_core/ROS2BaseLCNode.hpp
+++ b/include/kroshu_ros2_core/ROS2BaseLCNode.hpp
@@ -63,7 +63,7 @@ public:
   }
 
   template<typename T>
-  void registerArgument(
+  void registerStaticParameter(
     const std::string & name, const T & value, const ParameterSetAccessRights & rights,
     std::function<bool(const T &)> on_change_callback)
   {

--- a/include/kroshu_ros2_core/ROS2BaseLCNode.hpp
+++ b/include/kroshu_ros2_core/ROS2BaseLCNode.hpp
@@ -61,6 +61,16 @@ public:
       name, value, rights,
       on_change_callback, this->get_node_parameters_interface());
   }
+
+  template<typename T>
+  void registerArgument(
+    const std::string & name, const T & value, const ParameterSetAccessRights & rights,
+    std::function<bool(const T &)> on_change_callback)
+  {
+    param_handler_.registerParameter<T>(
+      name, value, rights,
+      on_change_callback, this->get_node_parameters_interface(), true);
+  }
   const ParameterHandler & getParameterHandler() const;
 
 protected:

--- a/include/kroshu_ros2_core/ROS2BaseNode.hpp
+++ b/include/kroshu_ros2_core/ROS2BaseNode.hpp
@@ -47,7 +47,7 @@ public:
   }
 
   template<typename T>
-  void registerArgument(
+  void registerStaticParameter(
     const std::string & name, const T & value,
     std::function<bool(const T &)> on_change_callback)
   {

--- a/include/kroshu_ros2_core/ROS2BaseNode.hpp
+++ b/include/kroshu_ros2_core/ROS2BaseNode.hpp
@@ -46,6 +46,16 @@ public:
       on_change_callback, this->get_node_parameters_interface());
   }
 
+  template<typename T>
+  void registerArgument(
+    const std::string & name, const T & value,
+    std::function<bool(const T &)> on_change_callback)
+  {
+    param_handler_.registerParameter<T>(
+      name, value,
+      on_change_callback, this->get_node_parameters_interface(), true);
+  }
+
 protected:
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr ParamCallback() const;
 

--- a/src/ParameterHandler.cpp
+++ b/src/ParameterHandler.cpp
@@ -71,11 +71,16 @@ bool ParameterHandler::canSetParameter(const ParameterBase & param) const
   return true;
 }
 
-void ParameterHandler::registerParameter(std::shared_ptr<ParameterBase> param_shared_ptr)
+void ParameterHandler::registerParameter(
+  std::shared_ptr<ParameterBase> param_shared_ptr,
+  bool block)
 {
   params_.emplace_back(param_shared_ptr);
   param_shared_ptr->getParameterInterface()->declare_parameter(
     param_shared_ptr->getName(), param_shared_ptr->getDefaultValue());
+  if (block) {
+    param_shared_ptr->blockParameter();
+  }
 }
 
 }  // namespace kroshu_ros2_core


### PR DESCRIPTION
Added _registerArgument()_ templated functions with the same syntax, as _registerParameter()_, but these parameters cannot be changed in runtime, after declarations the parameter set callbacks are change to always return false. 
This could be used for example for static robot data, where some limits should not be changed